### PR TITLE
accept all map implementations for attributes

### DIFF
--- a/liquid/src/main/java/io/lqd/sdk/Liquid.java
+++ b/liquid/src/main/java/io/lqd/sdk/Liquid.java
@@ -36,6 +36,7 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -341,7 +342,7 @@ public class Liquid {
      * @param attributes
      *            Additional user attributes.
      */
-    public void identifyUser(String identifier, HashMap<String, Object> attributes) {
+    public void identifyUser(String identifier, Map<String, Object> attributes) {
         identifyUser(identifier, attributes, true, true);
     }
 
@@ -356,12 +357,12 @@ public class Liquid {
      *            if true, will make an alias with previous user if previous
      *            user is anonymous.
      */
-    public void identifyUser(String identifier, HashMap<String, Object> attributes, boolean alias) {
+    public void identifyUser(String identifier, Map<String, Object> attributes, boolean alias) {
         identifyUser(identifier, attributes, true, alias);
     }
 
 
-    private void identifyUser(String identifier, HashMap<String, Object> attributes, boolean identified, boolean alias) {
+    private void identifyUser(String identifier, Map<String, Object> attributes, boolean identified, boolean alias) {
         final String finalIdentifier = identifier;
         final HashMap<String, Object> finalAttributes = LQModel.sanitizeAttributes(attributes, isDevelopmentMode);
 
@@ -433,7 +434,7 @@ public class Liquid {
         }
     }
 
-    public void setUserAttributes(final HashMap<String, Object> attributes) {
+    public void setUserAttributes(final Map<String, Object> attributes) {
         mQueue.execute(new Runnable() {
             @Override
             public void run() {
@@ -569,13 +570,13 @@ public class Liquid {
      * @param attributes
      *            Additional attributes of the event.
      */
-    public void track(String eventName, HashMap<String, Object> attributes) {
+    public void track(String eventName, Map<String, Object> attributes) {
         if (LQEvent.hasValidName(eventName, isDevelopmentMode)) {
             track(eventName, attributes, UniqueTime.newDate());
         }
     }
 
-    private void track(String eventName, HashMap<String, Object> attributes, Date date) {
+    private void track(String eventName, Map<String, Object> attributes, Date date) {
         if ((eventName == null) || (eventName.length() == 0)) {
             eventName = "unnamedEvent";
         }

--- a/liquid/src/main/java/io/lqd/sdk/model/LQModel.java
+++ b/liquid/src/main/java/io/lqd/sdk/model/LQModel.java
@@ -28,6 +28,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.UUID;
 
 import io.lqd.sdk.LQLog;
@@ -83,7 +84,7 @@ public abstract class LQModel implements Serializable {
         return isValid;
     }
 
-    public static HashMap<String, Object> sanitizeAttributes(HashMap<String, Object> attributes, boolean raiseException) {
+    public static HashMap<String, Object> sanitizeAttributes(Map<String, Object> attributes, boolean raiseException) {
         if (attributes == null) {
             return null;
         }

--- a/liquid/src/test/java/io/lqd/sdk/LiquidTest.java
+++ b/liquid/src/test/java/io/lqd/sdk/LiquidTest.java
@@ -6,15 +6,16 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
 
 import io.lqd.sdk.model.LQSession;
 import io.lqd.sdk.model.LQUser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 @Config(manifest = "../AndroidManifest.xml")
 @RunWith(RobolectricTestRunner.class)
@@ -61,7 +62,7 @@ public class LiquidTest {
         assertNotNull(f.get(lqd));
     }
 
-    // public void setUserAttributes(final HashMap<String, Object> attributes)
+    // public void setUserAttributes(final Map<String, Object> attributes)
 
     @Test
     public void testSetAttributes() throws NoSuchFieldException, IllegalAccessException, InterruptedException {


### PR DESCRIPTION
fixes https://github.com/lqd-io/liquid-sdk-android/issues/7

A small change to make using the Liquid SDK easier. The SDK doesn't care what the underlying map implementation is. 