### PR TITLE
Fix an issue with Android M support

### DIFF
--- a/liquid/build.gradle
+++ b/liquid/build.gradle
@@ -30,12 +30,12 @@ android {
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/NOTICE'
     }
-    compileSdkVersion 21
-    buildToolsVersion "19.1.0"
+    compileSdkVersion 23
+    buildToolsVersion '23.0.1'
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 21
+        targetSdkVersion 23
         versionCode 1
         versionName "1.2.0"
         testInstrumentationRunner "com.google.android.apps.common.testing.testrunner.GoogleInstrumentationTestRunner"
@@ -86,11 +86,12 @@ dependencies {
         exclude module: 'wagon-provider-api'
         exclude group: 'com.android.support', module: 'support-v4'
     }
-    androidTestCompile ('com.squareup:fest-android:1.0.+') {
+    androidTestCompile('com.squareup:fest-android:1.0.+') {
         exclude group: 'com.android.support', module: 'support-v4'
     }
     androidTestCompile 'org.mockito:mockito-all:1.10.5'
     compile 'com.google.android.gms:play-services:[3.1,)'
+    compile "com.android.support:support-v4:23.0.0"
 }
 
 apply plugin: 'idea'

--- a/liquid/src/main/java/io/lqd/sdk/LQPushHandler.java
+++ b/liquid/src/main/java/io/lqd/sdk/LQPushHandler.java
@@ -15,7 +15,6 @@
  */
 package io.lqd.sdk;
 
-import android.annotation.TargetApi;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -27,8 +26,8 @@ import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.net.Uri;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.provider.Settings;
+import android.support.v4.app.NotificationCompat;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
@@ -70,12 +69,7 @@ public class LQPushHandler extends BroadcastReceiver {
         String title = getPushTitle(intent, context);
         Intent appIntent = getIntent(context);
         PendingIntent contentIntent = PendingIntent.getActivity(context.getApplicationContext(), 0, appIntent, PendingIntent.FLAG_UPDATE_CURRENT);
-        if(Build.VERSION.SDK_INT < 11) {
-            sendNotification8(context, contentIntent, icon, push_id, title, message, sound);
-        } else {
-            sendNotification11(context, contentIntent, icon, push_id, title, message, sound);
-        }
-
+        sendNotification(context, contentIntent, icon, push_id, title, message, sound);
     }
 
     private void handleRegistration(Intent intent) {
@@ -115,37 +109,19 @@ public class LQPushHandler extends BroadcastReceiver {
     }
 
     @SuppressWarnings("deprecation")
-    @TargetApi(16)
-    private void sendNotification11(Context c, PendingIntent intent, int icon, int push_id, String title, String body, Uri sound) {
+    private void sendNotification(Context c, PendingIntent intent, int icon, int push_id, String title, String body, Uri sound) {
         NotificationManager nm = (NotificationManager) c.getSystemService(Context.NOTIFICATION_SERVICE);
-        Notification.Builder builder = new Notification.Builder(c);
-        builder.setSmallIcon(icon);
-        builder.setTicker(body);
-        builder.setContentText(body);
-        builder.setWhen(System.currentTimeMillis());
-        builder.setContentTitle(title);
-        builder.setContentIntent(intent);
-        if(sound != null)
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(c)
+                .setSmallIcon(icon)
+                .setTicker(body)
+                .setContentText(body)
+                .setWhen(System.currentTimeMillis())
+                .setContentTitle(title)
+                .setContentIntent(intent);
+        if (sound != null)
             builder.setSound(sound);
-        Notification n;
-        if (Build.VERSION.SDK_INT < 16) {
-            n = builder.getNotification();
-        } else {
-            n = builder.build();
-        }
+        Notification n = builder.build();
         n.flags |= Notification.FLAG_AUTO_CANCEL;
-        nm.notify(push_id, n);
-    }
-
-    @SuppressWarnings("deprecation")
-    @TargetApi(8)
-    private void sendNotification8(Context c, PendingIntent intent, int icon, int push_id, String title, String body, Uri sound) {
-        NotificationManager nm = (NotificationManager)c.getSystemService(Context.NOTIFICATION_SERVICE);
-        Notification n = new Notification(icon, body, System.currentTimeMillis());
-        n.flags |= Notification.FLAG_AUTO_CANCEL;
-        n.setLatestEventInfo(c, title, body, intent);
-        if(sound != null)
-            n.sound = sound;
         nm.notify(push_id, n);
     }
 

--- a/liquid/src/main/java/io/lqd/sdk/model/LQNetworkRequest.java
+++ b/liquid/src/main/java/io/lqd/sdk/model/LQNetworkRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,8 +18,6 @@ package io.lqd.sdk.model;
 
 import android.content.Context;
 import android.os.Build;
-
-import org.apache.http.entity.StringEntity;
 
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
@@ -46,14 +44,14 @@ public class LQNetworkRequest extends LQModel {
     private static final String LOCAL = Locale.getDefault().toString();
     private static final String DEVICE = Build.MANUFACTURER + " " + Build.MODEL;
 
-    private static final String USER_AGENT = "Liquid/"+ Liquid.LIQUID_VERSION + " (Android; Android " + Build.VERSION.RELEASE + "; " + LOCAL + "; " + DEVICE +")";
+    private static final String USER_AGENT = "Liquid/" + Liquid.LIQUID_VERSION + " (Android; Android " + Build.VERSION.RELEASE + "; " + LOCAL + "; " + DEVICE + ")";
     private String mUrl;
     private String mHttpMethod;
     private String mJson;
     private int mNumberOfTries;
     private Date mLastTry;
 
-    public LQNetworkRequest(String url, String httpMethod, String json){
+    public LQNetworkRequest(String url, String httpMethod, String json) {
         mUrl = url;
         mHttpMethod = httpMethod;
         mJson = json;
@@ -67,7 +65,7 @@ public class LQNetworkRequest extends LQModel {
     public String getHttpMethod() {
         return mHttpMethod;
     }
-    public String getJSON(){
+    public String getJSON() {
         return mJson;
     }
     public int getNumberOfTries() {
@@ -101,9 +99,9 @@ public class LQNetworkRequest extends LQModel {
     @Override
     public boolean equals(Object o) {
         return (o instanceof LQNetworkRequest) &&
-                ((LQNetworkRequest)o).getHttpMethod().equals(this.getHttpMethod()) &&
-                ((LQNetworkRequest)o).getUrl().equals(this.getUrl()) &&
-                ((LQNetworkRequest)o).getJSON().equals(this.getJSON());
+                ((LQNetworkRequest) o).getHttpMethod().equals(this.getHttpMethod()) &&
+                ((LQNetworkRequest) o).getUrl().equals(this.getUrl()) &&
+                ((LQNetworkRequest) o).getJSON().equals(this.getJSON());
     }
 
     // File Management
@@ -145,8 +143,8 @@ public class LQNetworkRequest extends LQModel {
                 connection.setDoOutput(true);
                 out = connection.getOutputStream();
                 bout = new BufferedOutputStream(out);
-                final StringEntity stringEntity = new StringEntity(this.getJSON(), "UTF-8");
-                stringEntity.writeTo(bout);
+                final String data = new String(getJSON().getBytes(), "UTF-8");
+                bout.write(data.getBytes());
             }
             responseCode = connection.getResponseCode();
             err = connection.getErrorStream();


### PR DESCRIPTION
I don't have a solid setup for testing this branch. The update to 23 build tools is probably worth a solid bit of testing. The key to fixing the issue is to remove the method setLatestEventInfo as it is no longer available.
https://github.com/lqd-io/liquid-sdk-android/issues/10

Additional change: org.apache.http.entity.StringEntity is also no longer available. There are loads of potential options here. I went for:

```Java
    final String data = new String(getJSON().getBytes(), "UTF-8");	
    bout.write(data.getBytes());
```
This is just to preserve the UTF-8 encoding. This code may work with simply 

```Java
    bout.write(getJSON().getBytes());
```